### PR TITLE
feat: ensure claim API is CID version agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ interface ClaimTable {
   /** Archive of the claim invocation */
   bytes: Uint8Array
 
-  /** The subject of the claim. */
+  /** The subject of the claim (base32 encoded V1 CID). */
   content: string // Note: partition key
 
   /** UCAN expiration */

--- a/package-lock.json
+++ b/package-lock.json
@@ -3096,6 +3096,29 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@ipld/dag-pb": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.4.tgz",
+      "integrity": "sha512-lX0c6ZAwD8ZKtjbawxotP8XNyR6z7/NIk7wXuhDlFT4MrNo/AOefZEUWjAw8CGz3EG3mau4P66VpsZwToVLHDg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@ipld/dag-ucan": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@ipld/dag-ucan/-/dag-ucan-3.3.2.tgz",
@@ -14921,7 +14944,7 @@
     },
     "packages/core": {
       "name": "@web3-storage/content-claims",
-      "version": "2.3.0",
+      "version": "3.0.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ucanto/client": "^8.0.0",
@@ -14969,6 +14992,7 @@
         "varint": "^6.0.0"
       },
       "devDependencies": {
+        "@ipld/dag-pb": "^4.0.4",
         "@types/aws-lambda": "^8.10.115",
         "@types/varint": "^6.0.1",
         "ava": "^5.3.1",

--- a/packages/core/src/server/api.ts
+++ b/packages/core/src/server/api.ts
@@ -3,7 +3,7 @@ import { UnknownLink, Link } from 'multiformats/link'
 export interface Claim {
   claim: Link
   bytes: Uint8Array
-  content: UnknownLink
+  content: Link
   expiration?: number
 }
 

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -23,6 +23,7 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
+    "@ipld/dag-pb": "^4.0.4",
     "@types/aws-lambda": "^8.10.115",
     "@types/varint": "^6.0.1",
     "ava": "^5.3.1",

--- a/packages/lambda/src/lib/store/index.js
+++ b/packages/lambda/src/lib/store/index.js
@@ -1,6 +1,7 @@
 import { UpdateItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import * as Link from 'multiformats/link'
+import { base32 } from 'multiformats/bases/base32'
 import retry from 'p-retry'
 import { DynamoTable } from './dynamo-table.js'
 
@@ -20,7 +21,7 @@ export class ClaimStorage extends DynamoTable {
       TableName: this.tableName,
       Key: marshall({
         claim: claim.toString(),
-        content: content.toString()
+        content: content.toV1().toString(base32)
       }),
       ExpressionAttributeValues: marshall({
         ':by': bytes,
@@ -38,7 +39,7 @@ export class ClaimStorage extends DynamoTable {
       KeyConditions: {
         content: {
           ComparisonOperator: 'EQ',
-          AttributeValueList: [{ S: content.toString() }]
+          AttributeValueList: [{ S: content.toV1().toString(base32) }]
         }
       },
       Limit: 100


### PR DESCRIPTION
This PR ensures the claim API is CID version agnostic by normalizing "content" CIDs to base32 encoded V1 before storage/retrieval in DynamoDB.