### PR TITLE
feat: add `assert/equals`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Input:
 }
 ```
 
+### Equivalency Claim
+
+Claims that the same data is referred to by another CID and/or multihash. For example a CAR CID and it's CommP Piece CID.
+
+Capability: `assert/equals`
+
+Input:
+
+```js
+{
+  content: CID /* CID */,
+  equals: CID /* CID */
+}
+```
+
 #### Relation claim 🆕
 
 Claims that a CID links to other CIDs. Like a [partition claim](#partition-claim) crossed with an [inclusion claim](#inclusion-claim), a relation claim asserts that a block of content links to other blocks, and that the block and it's links may be found in the specified parts. Furthermore, for each part you can optionally specify an inline inclusion claim (specifying what is included in the part) and for each inclusion an optional inline partition claim (specifying parts in which the inclusion CID may be found).

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -126,6 +126,23 @@ prog
     })
     await archiveClaim(invocation, opts.output)
   })
+  .command('equals <content> <equal>')
+  .describe('Generate an equals claim that asserts the content is referred to by another CID and/or multihash.')
+  .option('-o, --output', 'Write output to this file.')
+  .example('equals QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354 -o equals.claim')
+  .action(async (contentArg, equalsArg, opts) => {
+    const content = Link.parse(contentArg)
+    const equals = Link.parse(equalsArg)
+    const signer = getSigner()
+
+    const invocation = Assert.equals.invoke({
+      issuer: signer,
+      audience: servicePrincipal,
+      with: signer.did(),
+      nb: { content, equals }
+    })
+    await archiveClaim(invocation, opts.output)
+  })
   .command('inspect <claim>')
   .describe('Inspect a generated claim.')
   .action(async path => {

--- a/packages/core/src/capability/assert.js
+++ b/packages/core/src/capability/assert.js
@@ -6,6 +6,7 @@ import { capability, URI, Link, Schema } from '@ucanto/server'
  * @typedef {import('@ucanto/server').InferInvokedCapability<typeof inclusion>} AssertInclusion
  * @typedef {import('@ucanto/server').InferInvokedCapability<typeof partition>} AssertPartition
  * @typedef {import('@ucanto/server').InferInvokedCapability<typeof relation>} AssertRelation
+ * @typedef {import('@ucanto/server').InferInvokedCapability<typeof equals>} AssertEquals
  */
 
 export const assert = capability({
@@ -80,5 +81,17 @@ export const relation = capability({
         parts: Schema.array(Link.match({ version: 1 })).optional()
       }).optional()
     }))
+  })
+})
+
+/**
+ * Claim data is referred to by another CID and/or multihash. e.g CAR CID & CommP CID
+ */
+export const equals = capability({
+  can: 'assert/equals',
+  with: URI.match({ protocol: 'did:' }),
+  nb: Schema.struct({
+    content: Link,
+    equals: Link
   })
 })

--- a/packages/core/src/client/api.ts
+++ b/packages/core/src/client/api.ts
@@ -68,9 +68,9 @@ export interface RelationPartInclusion {
 
 /** A claim that the same data is referred to by another CID and/or multihash */
 export interface EqualsClaim extends ContentClaim<typeof Assert.equals.can> {
-  /** CIDs CID - the hash of the binary sorted links in the set. */
+  /** Any CID e.g a CAR CID */
   readonly content: Link
-  /** List of archives (CAR CIDs) containing the blocks. */
+  /** A CID that is equivalent to the content CID e.g the Piece CID for that CAR CID */
   readonly equals: Link
 }
 

--- a/packages/core/src/client/api.ts
+++ b/packages/core/src/client/api.ts
@@ -66,12 +66,21 @@ export interface RelationPartInclusion {
   parts?: Link[]
 }
 
+/** A claim that the same data is referred to by another CID and/or multihash */
+export interface EqualsClaim extends ContentClaim<typeof Assert.equals.can> {
+  /** CIDs CID - the hash of the binary sorted links in the set. */
+  readonly content: Link
+  /** List of archives (CAR CIDs) containing the blocks. */
+  readonly equals: Link
+}
+
 /** Types of claim that are known to this library. */
 export type KnownClaimTypes = 
   | typeof Assert.location.can
   | typeof Assert.partition.can
   | typeof Assert.inclusion.can
   | typeof Assert.relation.can
+  | typeof Assert.equals.can
 
 /** A verifiable claim about data. */
 export type Claim =
@@ -79,6 +88,7 @@ export type Claim =
   | PartitionClaim
   | InclusionClaim
   | RelationClaim
+  | EqualsClaim
   | UnknownClaim
 
 export interface ByteRange {

--- a/packages/core/src/client/index.js
+++ b/packages/core/src/client/index.js
@@ -53,7 +53,9 @@ const claimType = can =>
         ? Assert.inclusion.can
         : can === Assert.relation.can
           ? Assert.relation.can
-          : 'unknown'
+          : can === Assert.equals.can
+            ? Assert.equals.can
+            : 'unknown'
 
 /**
  * Fetch a CAR archive of claims from the service. Note: no verification is

--- a/packages/core/src/server/service/api.ts
+++ b/packages/core/src/server/service/api.ts
@@ -1,5 +1,5 @@
 import { Failure, ServiceMethod } from '@ucanto/server'
-import { AssertInclusion, AssertLocation, AssertPartition, AssertRelation } from '../../capability/assert.js'
+import { AssertInclusion, AssertLocation, AssertPartition, AssertRelation, AssertEquals } from '../../capability/assert.js'
 import { ClaimStore } from '../api.js'
 
 export interface AssertServiceContext {
@@ -11,6 +11,7 @@ export interface AssertService {
   inclusion: ServiceMethod<AssertInclusion, {}, Failure>
   partition: ServiceMethod<AssertPartition, {}, Failure>
   relation: ServiceMethod<AssertRelation, {}, Failure>
+  equals: ServiceMethod<AssertEquals, {}, Failure>
 }
 
 export interface ServiceContext extends AssertServiceContext {}

--- a/packages/core/src/server/service/assert.js
+++ b/packages/core/src/server/service/assert.js
@@ -10,7 +10,8 @@ export function createService (context) {
     inclusion: Server.provide(Assert.inclusion, input => handler(input, context)),
     location: Server.provide(Assert.location, input => handler(input, context)),
     partition: Server.provide(Assert.partition, input => handler(input, context)),
-    relation: Server.provide(Assert.relation, input => handler(input, context))
+    relation: Server.provide(Assert.relation, input => handler(input, context)),
+    equals: Server.provide(Assert.equals, input => handler(input, context))
   }
 }
 

--- a/packages/core/test/server.spec.js
+++ b/packages/core/test/server.spec.js
@@ -6,7 +6,7 @@ import { encode as encodeCAR, link as linkCAR } from '@ucanto/core/car'
 import { connect } from '@ucanto/client'
 import { mock } from 'node:test'
 import * as Block from 'multiformats/block'
-import { sha256 } from 'multiformats/hashes/sha2'
+import { sha256, sha512 } from 'multiformats/hashes/sha2'
 import * as Bytes from 'multiformats/bytes'
 import * as dagCBOR from '@ipld/dag-cbor'
 import { Server } from '../src/index.js'
@@ -75,5 +75,52 @@ export const test = {
     assert.ok(cap)
     assert.equal(cap.nb.children.length, 1)
     assert.equal(cap.nb.children[0].toString(), child.cid.toString())
+  },
+
+  'should claim equals': async (/** @type {import('entail').assert} */ assert) => {
+    const { claimStore, signer, server } = await beforeEach()
+    const value = 'two face'
+    const content = await Block.encode({ value, hasher: sha256, codec: dagCBOR })
+    const equals = await Block.encode({ value, hasher: sha512, codec: dagCBOR })
+
+    const claimPut = mock.method(claimStore, 'put')
+
+    const connection = connect({
+      id: signer,
+      codec: CAR.outbound,
+      channel: server
+    })
+
+    const result = await Assert.equals
+      .invoke({
+        issuer: signer,
+        audience: signer,
+        with: signer.did(),
+        nb: {
+          content: content.cid,
+          equals: equals.cid
+        }
+      })
+      .execute(connection)
+
+    assert.ok(!result.out.error)
+    assert.ok(result.out.ok)
+
+    assert.equal(claimPut.mock.callCount(), 1)
+
+    const [claim] = await claimStore.get(content.cid)
+    assert.ok(claim)
+
+    assert.ok(Bytes.equals(claim.content.bytes, content.cid.multihash.bytes))
+    assert.ok(claim.claim)
+
+    const delegation = await Delegation.extract(claim.bytes)
+
+    /** @type {Assert.AssertEquals|undefined} */
+    // @ts-expect-error
+    const cap = delegation?.ok?.capabilities[0]
+
+    assert.ok(cap)
+    assert.equal(cap.nb.equals.toString(), equals.cid.toString())
   }
 }


### PR DESCRIPTION
`assert/equals` or Equivalency Claims are for cases in which the same data is referred to by another CID and/or multihash.

see: https://hackmd.io/@gozala/content-claims#Equivalency-Claims

License: MIT