### PR TITLE
feat: store equals for both content and equals multihash

### DIFF
--- a/packages/core/src/client/api.ts
+++ b/packages/core/src/client/api.ts
@@ -69,9 +69,9 @@ export interface RelationPartInclusion {
 /** A claim that the same data is referred to by another CID and/or multihash */
 export interface EqualsClaim extends ContentClaim<typeof Assert.equals.can> {
   /** Any CID e.g a CAR CID */
-  readonly content: Link
+  readonly content: UnknownLink
   /** A CID that is equivalent to the content CID e.g the Piece CID for that CAR CID */
-  readonly equals: Link
+  readonly equals: UnknownLink
 }
 
 /** Types of claim that are known to this library. */

--- a/packages/core/src/server/api.ts
+++ b/packages/core/src/server/api.ts
@@ -1,11 +1,13 @@
 import { MultihashDigest } from 'multiformats/hashes/digest'
 import { UnknownLink, Link } from 'multiformats/link'
+import { AnyAssertCap } from './service/api'
 
 export interface Claim {
   claim: Link
   bytes: Uint8Array
   content: MultihashDigest
-  expiration?: number
+  expiration?: number,
+  value: AnyAssertCap
 }
 
 export interface ClaimFetcher {

--- a/packages/core/src/server/service/api.ts
+++ b/packages/core/src/server/service/api.ts
@@ -2,6 +2,8 @@ import { Failure, ServiceMethod } from '@ucanto/server'
 import { AssertInclusion, AssertLocation, AssertPartition, AssertRelation, AssertEquals } from '../../capability/assert.js'
 import { ClaimStore } from '../api.js'
 
+export type AnyAssertCap = AssertInclusion | AssertLocation | AssertPartition | AssertRelation | AssertEquals
+
 export interface AssertServiceContext {
   claimStore: ClaimStore
 }

--- a/packages/core/src/server/service/assert.js
+++ b/packages/core/src/server/service/assert.js
@@ -16,11 +16,9 @@ export function createService (context) {
 }
 
 /**
- * @template {import('@ucanto/interface').Ability} Can
- * @template {import('@ucanto/interface').URI} Resource
- * @template {{ content: import('multiformats').Link }} Caveats
- * @template {import('@ucanto/interface').ParsedCapability<Can, Resource, Caveats>} ParsedCap
- * @param {import('@ucanto/interface').ProviderInput<ParsedCap>} input
+ * @param {object} config
+ * @param {import('./api').AnyAssertCap} config.capability
+ * @param {import('@ucanto/interface').Invocation} config.invocation
  * @param {import('./api').AssertServiceContext} context
  * @returns {Promise<import('@ucanto/server').Result<{}, import('@ucanto/server').Failure>>}
  */
@@ -32,7 +30,8 @@ export const handler = async ({ capability, invocation }, { claimStore }) => {
     claim: invocation.cid,
     bytes: archive.ok,
     content: content.multihash,
-    expiration: invocation.expiration
+    expiration: invocation.expiration,
+    value: capability
   }
   await claimStore.put(claim)
   return { ok: {} }

--- a/packages/lambda/src/lib/store/index.js
+++ b/packages/lambda/src/lib/store/index.js
@@ -5,6 +5,7 @@ import * as Link from 'multiformats/link'
 import * as Multihash from 'multiformats/hashes/digest'
 import { base32 } from 'multiformats/bases/base32'
 import { base58btc } from 'multiformats/bases/base58'
+import * as Bytes from 'multiformats/bytes'
 import retry from 'p-retry'
 
 /**
@@ -34,37 +35,22 @@ export class ClaimStorage {
   }
 
   /** @param {import('@web3-storage/content-claims/server/api').Claim} claim */
-  async put ({ claim, bytes, content, expiration }) {
-    const hasExpiration = expiration && isFinite(expiration)
-    const cidstr = claim.toString(base32)
+  async put (claim) {
     await Promise.all([
-      retry(() => {
-        const cmd = new PutObjectCommand({
-          Bucket: this.#bucket.bucketName,
-          Key: `${cidstr}/${cidstr}.car`,
-          Body: bytes
-        })
-        return this.#bucket.s3Client.send(cmd)
-      }, {
-        minTimeout: 100,
-        onFailedAttempt: err => console.warn(`failed S3 put for: ${cidstr}`, err)
-      }),
-      retry(() => {
-        const cmd = new UpdateItemCommand({
-          TableName: this.#table.tableName,
-          Key: marshall({
-            claim: claim.toString(),
-            content: base58btc.encode(content.bytes)
-          }),
-          ExpressionAttributeValues: marshall({ ':ex': hasExpiration ? expiration : 0 }),
-          UpdateExpression: 'SET expiration=:ex'
-        })
-        return this.#table.dynamoClient.send(cmd)
-      }, {
-        minTimeout: 100,
-        onFailedAttempt: err => console.warn(`failed DynamoDB update for: ${cidstr}`, err)
-      })
+      storeClaimBytes(claim, this.#bucket),
+      upsertClaim(claim, this.#table)
     ])
+    const { content, value } = claim
+    if (value.can === 'assert/equals') {
+      const equivalent = value.nb.equals.multihash
+      if (Bytes.equals(content.bytes, equivalent.bytes)) {
+        // the multihash matches so this claim will appear in queries for either CID already.
+        return
+      }
+      // also add the claim with the `equals` cid as the `content` cid,
+      // so we can provide the equivalent claim for look ups for either.
+      await upsertClaim({ ...claim, content: equivalent }, this.#table)
+    }
   }
 
   /** @param {import('@ucanto/server').UnknownLink} content */
@@ -105,4 +91,48 @@ export class ClaimStorage {
       })
     }))
   }
+}
+
+/**
+ * @param {import('@web3-storage/content-claims/server/api').Claim} claim
+ * @param {import('./s3-bucket').S3Bucket} s3
+ **/
+async function storeClaimBytes ({ claim, bytes }, { bucketName, s3Client }) {
+  const cidstr = claim.toString(base32)
+  const key = `${cidstr}/${cidstr}.car`
+  return retry(() => {
+    const cmd = new PutObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+      Body: bytes
+    })
+    return s3Client.send(cmd)
+  }, {
+    minTimeout: 100,
+    onFailedAttempt: err => console.warn(`failed S3 put for: ${cidstr}`, err)
+  })
+}
+
+/**
+ * @param {import('@web3-storage/content-claims/server/api').Claim} claim
+ * @param {import('./dynamo-table').DynamoTable} dynamo
+ */
+async function upsertClaim ({ claim, content, expiration }, { tableName, dynamoClient }) {
+  const hasExpiration = expiration && isFinite(expiration)
+  const mh = base58btc.encode(content.bytes)
+  return retry(() => {
+    const cmd = new UpdateItemCommand({
+      TableName: tableName,
+      Key: marshall({
+        claim: claim.toString(),
+        content: mh
+      }),
+      ExpressionAttributeValues: marshall({ ':ex': hasExpiration ? expiration : 0 }),
+      UpdateExpression: 'SET expiration=:ex'
+    })
+    return dynamoClient.send(cmd)
+  }, {
+    minTimeout: 100,
+    onFailedAttempt: err => console.warn(`failed DynamoDB update for: ${mh}`, err)
+  })
 }

--- a/packages/lambda/src/lib/store/index.js
+++ b/packages/lambda/src/lib/store/index.js
@@ -124,7 +124,7 @@ async function upsertClaim ({ claim, content, expiration }, { tableName, dynamoC
     const cmd = new UpdateItemCommand({
       TableName: tableName,
       Key: marshall({
-        claim: claim.toString(),
+        claim: claim.toString(base32),
         content: mh
       }),
       ExpressionAttributeValues: marshall({ ':ex': hasExpiration ? expiration : 0 }),
@@ -133,6 +133,6 @@ async function upsertClaim ({ claim, content, expiration }, { tableName, dynamoC
     return dynamoClient.send(cmd)
   }, {
     minTimeout: 100,
-    onFailedAttempt: err => console.warn(`failed DynamoDB update for: ${mh}`, err)
+    onFailedAttempt: err => console.warn(`failed DynamoDB update for content: ${mh} claim: ${claim.toString(base32)}`, err)
   })
 }


### PR DESCRIPTION
We want to return equals claims when quired with either the content cid or the equals cid, so store 2 records in dynamo for equals claims.

`assert/equals` claims provide 2 CIDs. The `content` CID and the `equals` CID that we claim the `content` CID is equivelant to. (e.g. different hash fn for same bytes)

The dynamo records are `{ content: "base58btc-multihash", claim: CID }`. The actual bytes of the claim are stored in s3, only once per claim.

For equals claims we store an additional record that sets the `content` to the multihash of the provided `equals` CID.

**Alternatively** we could have stored an `equals` property on dynamo records for equals claims, and added a global secondary index for that field, and updated the query to check both the content field and the equals field (and the secondary index) for every query, but this would incur additonal read costs for *every* query. It is assumed that storing a extra tuple of [string,cid] per equals claim will be cheap, and avoids a larger refactor of the claims db.

License: MIT