### PR TITLE
fix: walk must be array when passed to client

### DIFF
--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -177,7 +177,8 @@ prog
   .option('-o, --output', 'Write output to this file.')
   .action(async (contentArg, opts) => {
     const content = Link.parse(contentArg)
-    const res = await Client.fetch(content, { walk: opts.walk, serviceURL })
+    const walk = Array.isArray(opts.walk) ? opts.walk : opts.walk?.split(',')
+    const res = await Client.fetch(content, { walk, serviceURL })
     if (!res.ok) throw new Error(`unexpected service status: ${res.status}`, { cause: await res.text() })
     if (!res.body) throw new Error('missing response body')
 


### PR DESCRIPTION
Ensure the walk param is converted to an array before passing it to the client

sade opts handling:

| input | output |
|-------|--------|
|`--walk foo` | `{ opts: { walk: 'foo' }}` |
| `--walk foo --walk bar` | `{ opts: { walk: ['foo', 'bar'] }}` | 
| `--walk foo,bar` | `{ opts: { walk: 'foo,bar' }` |

as such we needed to manually split on comma where provided, or upgrade to an array where only a single option was provided.

License: MIT