### PR TITLE
feat: `--expire` flag support for cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11703,6 +11703,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
+    },
     "node_modules/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -14926,6 +14931,7 @@
         "carstream": "^1.0.2",
         "dotenv": "^16.3.1",
         "multiformats": "^12.0.1",
+        "parse-duration": "^1.1.0",
         "sade": "^1.8.1",
         "typescript": "^5.1.6"
       },
@@ -14944,7 +14950,7 @@
     },
     "packages/core": {
       "name": "@web3-storage/content-claims",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ucanto/client": "^8.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "carstream": "^1.0.2",
     "dotenv": "^16.3.1",
     "multiformats": "^12.0.1",
+    "parse-duration": "^1.1.0",
     "sade": "^1.8.1",
     "typescript": "^5.1.6"
   }


### PR DESCRIPTION
Pass `--expire never` to create a content-claim assertion that never expires (`exp: null`)

Pass `--expire 1d` to have it expire in 1d. Supports duration strings from [`parse-duration`](https://github.com/jkroso/parse-duration)

Makes the current implcit 30s from ucanto the explicit default so it appears in the help text

```shell
❯ ./bin.js equals --help

  Description
    Generate an equals claim that asserts the content is referred to by another CID and/or multihash.

  Usage
    $ claim equals <content> <equal> [options]

  Options
    -o, --output    Write output to this file.
    -e, --expire    Duration after which claim expires e.g '1min' or '1hr'  (default 30s)
    -h, --help      Displays this message

  Examples
    $ claim equals QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354 -o equals.claim

```

see: https://github.com/ucan-wg/spec#323-time-bounds

fixes: https://github.com/web3-storage/content-claims/issues/28

License: MIT