### PR TITLE
fix: fix content-claims package not being importable by ts project by having package.json point to src alongside types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14974,10 +14974,11 @@
     },
     "packages/core": {
       "name": "@web3-storage/content-claims",
-      "version": "3.2.1",
+      "version": "4.0.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ucanto/client": "^9.0.0",
+        "@ucanto/interface": "^9.0.0",
         "@ucanto/server": "^9.0.1",
         "@ucanto/transport": "^9.0.0",
         "carstream": "^1.0.2",
@@ -14985,7 +14986,6 @@
       },
       "devDependencies": {
         "@ipld/dag-cbor": "^9.0.3",
-        "@ucanto/interface": "^9.0.0",
         "@ucanto/principal": "^9.0.0",
         "cardex": "^2.3.0",
         "entail": "^2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@web3-storage/content-claims",
   "version": "4.0.0",
   "description": "Implementation of the Content Claims Protocol.",
-  "main": "src/index.js",
+  "main": "./types/index.js",
   "types": "./types/index.d.ts",
   "type": "module",
   "scripts": {
@@ -39,39 +39,39 @@
   ],
   "exports": {
     ".": {
-      "import": "./src/index.js",
+      "import": "./types/index.js",
       "types": "./types/index.d.ts"
     },
     "./server": {
-      "import": "./src/server/index.js",
+      "import": "./types/server/index.js",
       "types": "./types/server/index.d.ts"
     },
     "./server/api": {
-      "import": "./src/server/api.js",
+      "import": "./types/server/api.js",
       "types": "./types/server/api.d.ts"
     },
     "./server/service": {
-      "import": "./src/server/service/index.js",
+      "import": "./types/server/service/index.js",
       "types": "./types/server/service/index.d.ts"
     },
     "./server/service/api": {
-      "import": "./src/server/service/api.js",
+      "import": "./types/server/service/api.js",
       "types": "./types/server/service/index.d.ts"
     },
     "./client": {
-      "import": "./src/client/index.js",
+      "import": "./types/client/index.js",
       "types": "./types/client/index.d.ts"
     },
     "./client/api": {
-      "import": "./src/client/api.js",
+      "import": "./types/client/api.js",
       "types": "./types/client/api.d.ts"
     },
     "./capability": {
-      "import": "./src/capability/index.js",
+      "import": "./types/capability/index.js",
       "types": "./types/capability/index.d.ts"
     },
     "./capability/assert": {
-      "import": "./src/capability/assert.js",
+      "import": "./types/capability/assert.js",
       "types": "./types/capability/assert.d.ts"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc --build",
-    "lint": "standard && tsc",
+    "lint": "standard src test && tsc",
     "test": "entail"
   },
   "author": "Alan Shaw",

--- a/packages/core/src/capability/api.ts
+++ b/packages/core/src/capability/api.ts
@@ -1,0 +1,9 @@
+import * as ucanto from '@ucanto/interface'
+import { assert, equals, inclusion, location, partition, relation } from './assert.js'
+
+export type Assert = ucanto.InferInvokedCapability<typeof assert>
+export type AssertInclusion = ucanto.InferInvokedCapability<typeof inclusion>
+export type AssertLocation = ucanto.InferInvokedCapability<typeof location>
+export type AssertPartition = ucanto.InferInvokedCapability<typeof partition>
+export type AssertRelation = ucanto.InferInvokedCapability<typeof relation>
+export type AssertEquals = ucanto.InferInvokedCapability<typeof equals>

--- a/packages/core/src/capability/assert.js
+++ b/packages/core/src/capability/assert.js
@@ -1,14 +1,5 @@
 import { capability, URI, Link, Schema } from '@ucanto/server'
 
-/**
- * @typedef {import('@ucanto/server').InferInvokedCapability<typeof assert>} Assert
- * @typedef {import('@ucanto/server').InferInvokedCapability<typeof location>} AssertLocation
- * @typedef {import('@ucanto/server').InferInvokedCapability<typeof inclusion>} AssertInclusion
- * @typedef {import('@ucanto/server').InferInvokedCapability<typeof partition>} AssertPartition
- * @typedef {import('@ucanto/server').InferInvokedCapability<typeof relation>} AssertRelation
- * @typedef {import('@ucanto/server').InferInvokedCapability<typeof equals>} AssertEquals
- */
-
 export const assert = capability({
   can: 'assert/*',
   with: URI.match({ protocol: 'did:' })

--- a/packages/core/src/server/service/api.ts
+++ b/packages/core/src/server/service/api.ts
@@ -1,5 +1,5 @@
 import { Failure, ServiceMethod } from '@ucanto/server'
-import { AssertInclusion, AssertLocation, AssertPartition, AssertRelation, AssertEquals } from '../../capability/assert.js'
+import { AssertInclusion, AssertLocation, AssertPartition, AssertRelation, AssertEquals } from '../../capability/api.js'
 import { ClaimStore } from '../api.js'
 
 export type AnyAssertCap = AssertInclusion | AssertLocation | AssertPartition | AssertRelation | AssertEquals

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
     "outDir": "types",
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/content-claims/issues/40

Notes
* when I do `npm pack` of the packages/core in here and then `npm install file:<path-to-it>` in hoverboard, it resolves the issue