### PR TITLE
fix: export capability api in types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,10 @@
       "import": "./types/capability/index.js",
       "types": "./types/capability/index.d.ts"
     },
+    "./capability/api": {
+      "import": "./types/capability/api.js",
+      "types": "./types/capability/api.d.ts"
+    },
     "./capability/assert": {
       "import": "./types/capability/assert.js",
       "types": "./types/capability/assert.d.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,6 +102,9 @@
       "capability": [
         "types/capability/index.d.ts"
       ],
+      "capability/api": [
+        "types/capability/api.d.ts"
+      ],
       "capability/assert": [
         "types/capability/assert.d.ts"
       ]


### PR DESCRIPTION
Need this to import for inclusion claim for filecoin and noticed it was not exported