### PR TITLE
refactor: move claims walking code to published package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14974,7 +14974,7 @@
     },
     "packages/core": {
       "name": "@web3-storage/content-claims",
-      "version": "4.0.0",
+      "version": "4.0.2",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ucanto/client": "^9.0.0",

--- a/packages/core/src/server/index.js
+++ b/packages/core/src/server/index.js
@@ -1,4 +1,8 @@
+/* global ReadableStream */
 import * as Server from '@ucanto/server'
+import * as Delegation from '@ucanto/core/delegation'
+import * as Link from 'multiformats/link'
+import { sha256 } from 'multiformats/hashes/sha2'
 import { createService } from './service/index.js'
 
 /** @typedef {import('@ucanto/interface').ServerView<import('./service/api.js').Service>} Server */
@@ -20,3 +24,70 @@ export const createServer = ({ id, codec, errorReporter: errorHandler, validateA
     catch: errorHandler?.catch,
     validateAuthorization
   })
+
+/**
+ * Fetch claims for the passed content CID and walk the specified paths,
+ * returning a stream of content claims.
+ *
+ * @param {{ claimFetcher: import('./api.js').ClaimFetcher }} context
+ * @param {import('multiformats').UnknownLink} content
+ * @param {Set<string>} walk
+ */
+export const walkClaims = (context, content, walk) => {
+  const queue = [content]
+  /** @type {ReadableStream<import('carstream/api').Block>} */
+  const readable = new ReadableStream({
+    async pull (controller) {
+      const content = queue.shift()
+      if (!content) return controller.close()
+
+      const results = await context.claimFetcher.get(content)
+      if (!results.length) return
+
+      for (const result of results) {
+        controller.enqueue({
+          cid: Link.create(0x0202, await sha256.digest(result.bytes)),
+          bytes: result.bytes
+        })
+
+        if (walk.size) {
+          const claim = await Delegation.extract(result.bytes)
+          if (claim.error) {
+            console.error(claim.error)
+            continue
+          }
+
+          const nb = claim.ok.capabilities[0].nb
+          if (!nb) continue
+
+          /** @param {object} obj */
+          const walkKeys = obj => {
+            for (const key of Object.keys(obj).filter(k => k !== 'content')) {
+              // @ts-expect-error
+              const content = obj[key]
+              if (walk.has(key)) {
+                if (Array.isArray(content)) {
+                  for (const c of content) {
+                    if (Link.isLink(c)) {
+                      queue.push(c)
+                    } else if (content && typeof content === 'object') {
+                      walkKeys(content)
+                    }
+                  }
+                } else if (Link.isLink(content)) {
+                  queue.push(content)
+                } else if (content && typeof content === 'object') {
+                  walkKeys(content)
+                }
+              }
+            }
+          }
+
+          walkKeys(nb)
+        }
+      }
+    }
+  })
+
+  return readable
+}


### PR DESCRIPTION
This PR just moves the code that walks claims out of the lambda and into the package published to npm. I need this for local.storage.